### PR TITLE
Don't use [[likely]] on AppleClang 12

### DIFF
--- a/include/outcome/try.hpp
+++ b/include/outcome/try.hpp
@@ -164,10 +164,13 @@ OUTCOME_V2_NAMESPACE_END
 #define _OUTCOME_TRY_CALL_OVERLOAD(name, ...)                                                                                                                  \
   _OUTCOME_TRY_OVERLOAD_GLUE(_OUTCOME_TRY_OVERLOAD_MACRO(name, _OUTCOME_TRY_COUNT_ARGS_MAX8(__VA_ARGS__)), (__VA_ARGS__))
 
-#ifndef OUTCOME_TRY_LIKELY_IF
-#if(__cplusplus >= 202000L || _HAS_CXX20) && (!defined(__clang__) || __clang_major__ >= 12) && (!defined(__GNUC__) || defined(__clang__) || __GNUC__ >= 9)
+#if !defined(OUTCOME_TRY_LIKELY_IF) && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(likely)
 #define OUTCOME_TRY_LIKELY_IF(...) if(__VA_ARGS__) [[likely]]
-#elif defined(__clang__) || defined(__GNUC__)
+#endif
+#endif
+#ifndef OUTCOME_TRY_LIKELY_IF
+#if defined(__clang__) || defined(__GNUC__)
 #define OUTCOME_TRY_LIKELY_IF(...) if(__builtin_expect(!!(__VA_ARGS__), true))
 #else
 #define OUTCOME_TRY_LIKELY_IF(...) if(__VA_ARGS__)


### PR DESCRIPTION
AppleClang 12 doesn't support [[likely]], and warns about an unused
attribute. AppleClang 13 *does* support [[likely]].
